### PR TITLE
Fix database query execution

### DIFF
--- a/library/Core/Storage/Query.php
+++ b/library/Core/Storage/Query.php
@@ -337,7 +337,7 @@
 			$this->param_var = array();
 
 			// Execute query
-			$result = $query->execute(array());
+			$result = $query->execute();
 			
 			// Execution failed
 			if ($result === false)


### PR DESCRIPTION
The [PHP documentation for PDOStatement::execute](http://php.net/manual/en/pdostatement.execute.php) says:

> If the prepared statement included parameter markers, you must either:
> - call PDOStatement::bindParam() and/or PDOStatement::bindValue() to bind either variables or values (respectively) to the parameter markers. Bound variables pass their value as input and receive the output value, if any, of their associated parameter markers
> - or pass an array of input-only parameter values

At least in PHP 7, passing an empty array to `execute()` results in there being no bound parameters at all, i.e. the parameters bound using `bindParam()` or `bindValue()` are ignored. Perhaps behaves differently in HHVM?