### PR TITLE
Fix bug where wrong Reference values were preselected in dialog

### DIFF
--- a/typescript/Tinycar/Ui/Component/Reference.ts
+++ b/typescript/Tinycar/Ui/Component/Reference.ts
@@ -123,6 +123,17 @@ module Tinycar.Ui.Component
 				this.htmlItems[id].remove();
 				delete this.htmlItems[id];
 			}
+
+			// Find value from current value
+			let value = this.getDataValue();
+			let index = value.indexOf(id);
+
+			// Remove value from list
+			if (index > -1)
+				value.splice(index, 1);
+
+			// Update value
+			this.setDataValue(value);
 		}
 		
 		


### PR DESCRIPTION
Removing Reference field items by clicking on them in the form wouldn't update the value list in the select dialog. This fix uses the same approach as in TagsList.