### PR TITLE
Add keyboard events to Toggle component for better keyboard a11y

### DIFF
--- a/typescript/Tinycar/Ui/Component/Toggle.ts
+++ b/typescript/Tinycar/Ui/Component/Toggle.ts
@@ -2,8 +2,8 @@ module Tinycar.Ui.Component
 {
 	export class Toggle extends Tinycar.Main.Field
 	{
-	
-	
+		private htmlContainer:JQuery;
+
 		// Build content
 		buildContent()
 		{
@@ -11,58 +11,69 @@ module Tinycar.Ui.Component
 			super.buildContent();
 			this.buildToggle();
 		}
-		
+
 		// Build toggle element
 		private buildToggle():void
 		{
 			// Create container
-			var container = $('<a>').
+			this.htmlContainer = $('<a>').
 				attr('href', '#toggle').
 				attr('class', 'toggle').
 				appendTo(this.htmlContent);
-				
+
 			// Add icon
 			$('<span>').
 				attr('class', 'icon icon-lite icon-tiny icon-check').
-				appendTo(container);
-			
+				appendTo(this.htmlContainer);
+
 			// Add handle
 			let handle = $('<span>').
 				attr('class', 'handle').
-				appendTo(container);
-			
+				appendTo(this.htmlContainer);
+
 			// Add icon
 			$('<span>').
 				attr('class', 'icon icon-tiny icon-handle').
 				appendTo(handle);
-			
+
 			// Set initial style
 			if (this.getDataValue() === true)
 			{
-				container.addClass('is-active');
-				
+				this.htmlContainer.addClass('is-active');
+
 				if (this.isTypeEnabled() === true)
-					container.addClass('theme-base-lite');				
+					this.htmlContainer.addClass('theme-base-lite');
 			}
-			
+
 			// When clicked
-			container.click((e:Event) =>
+			this.htmlContainer.click((e:Event) =>
 			{
 				e.preventDefault();
-				
+
 				// Change value when clicked if field is enabled
 				if (this.isTypeEnabled() == true)
 				{
 					// Toggle class name
-					container.toggleClass('is-active');
-					container.toggleClass('theme-base-lite');
-							
+					this.htmlContainer.toggleClass('is-active');
+					this.htmlContainer.toggleClass('theme-base-lite');
+
 					// Update value
 					this.setDataValue(
 						!(this.getDataValue() === true)
 					);
 				}
-			});			
+			});
+
+			// When key is pressed
+			this.htmlContainer.keydown((e:JQueryKeyEventObject) =>
+			{
+				// Move toggle switch when space bar is pressed
+				if (e.which === 32)
+				{
+					e.preventDefault();
+					this.htmlContainer.click();
+				}
+			});
 		}
 	}
 }


### PR DESCRIPTION
Toggle component value can be toggled using space bar (same as native checkbox inputs).

No style changes – focus outline etc. – included.