### PR TITLE
Add keyboard events to Tabs for better keyboard a11y

### DIFF
--- a/typescript/Tinycar/View/Tabs.ts
+++ b/typescript/Tinycar/View/Tabs.ts
@@ -5,12 +5,12 @@ module Tinycar.View
 		name:string;
 		label:string;
 	}
-	
+
 	interface IHtmlTabs
 	{
 		[key:string]:JQuery;
 	}
-	
+
 	export class Tabs
 	{
 		private activeTab:string;
@@ -19,59 +19,83 @@ module Tinycar.View
 		private tabList:Array<Object> = [];
 		private tabNames:Array<string> = [];
 		private View:Tinycar.Ui.View;
-	
-	
+
+
 		// Initiate class
 		constructor(view:Tinycar.Ui.View)
 		{
 			this.View = view;
 		}
-		
+
 		// Add new tab item
 		addItem(item:ITabItem):void
 		{
 			this.tabList.push(item);
 		}
-	
+
 		// Build
 		build():JQuery
 		{
 			// Build elements
 			this.buildRoot();
 			this.buildLine();
-			
+
 			// Build tabs
-			this.tabList.forEach((item:Object) =>
+			this.tabList.forEach((item:Object, index:number) =>
 			{
-				this.buildItem(item);
+				this.buildItem(item, index);
 			});
-			
+
 			return this.htmlRoot;
 		}
-		
+
 		// Build new tab item
-		private buildItem(item:Object):void
+		private buildItem(item:Object, index:number):void
 		{
 			// Create link container
 			let container = $('<a>').
 				attr('class', 'item').
+				attr('tabindex', 0).
 				text(item['label']).
 				appendTo(this.htmlRoot);
-			
+
 			// When clicked
 			container.click((e:Event) =>
 			{
 				e.preventDefault();
 				this.View.showTab(item['name']);
 			});
-			
+
+			// When key is pressed
+			container.keydown((e:JQueryKeyEventObject) =>
+			{
+				// Open dialog when space bar or Enter is pressed
+				if (e.which === 32 || e.which === 13)
+				{
+					e.preventDefault();
+					container.click();
+				}
+				// Focus to previous tab link
+				else if (e.which === 37 && index !== 0)
+				{
+					e.preventDefault();
+					$(e.target).prev().focus();
+				}
+				// Focus to next tab link
+				else if (e.which === 39 && index !== this.tabNames.length - 1)
+				{
+					e.preventDefault();
+					$(e.target).next().focus();
+				}
+			});
+
 			// Add name to list
 			this.tabNames.push(item['name']);
-			
+
 			// Remember instance
 			this.htmlTabs[item['name']] = container;
 		}
-		
+
 		// Build lien
 		private buildLine():void
 		{
@@ -79,28 +103,28 @@ module Tinycar.View
 				attr('class', 'line').
 				appendTo(this.htmlRoot);
 		}
-		
+
 		// Build root container
 		private buildRoot():void
 		{
 			this.htmlRoot = $('<div>').
 				attr('class', 'tinycar-view-tabs');
 		}
-		
+
 		// Get first available tab name
 		getFirstTab():string
 		{
-			return (this.tabNames.length > 0 ? 
+			return (this.tabNames.length > 0 ?
 				this.tabNames[0] : 'default'
 			);
 		}
-		
+
 		// Get current active name
 		getActiveTab():string
 		{
 			return this.activeTab;
 		}
-		
+
 		// Set specified tab name as active
 		setActiveTab(name:string):void
 		{
@@ -111,10 +135,10 @@ module Tinycar.View
 					removeClass('is-active').
 					removeClass('theme-border');
 			}
-			
+
 			// Remember
 			this.activeTab = name;
-			
+
 			// Select new tab
 			if (this.htmlTabs.hasOwnProperty(name))
 			{


### PR DESCRIPTION
Tab links can be navigated to using Tab, left arrow and right arrow, and tab can be opened using space bar or Enter.

No style changes – focus outline etc. – included.